### PR TITLE
A-Assertions: enable assertions and document internal invariants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ test { useJUnitPlatform() }
 
 application {
     mainClass = 'hhvrfn.Launcher'
+    applicationDefaultJvmArgs = ['-ea']
 }
 
 shadowJar {

--- a/src/main/java/hhvrfn/Parser.java
+++ b/src/main/java/hhvrfn/Parser.java
@@ -21,6 +21,9 @@ public final class Parser {
      * @throws HhvrfnException For user errors or I/O errors reported in a user-friendly way.
      */
     public static void process(String input, TaskList tasks, Ui ui, Storage storage) throws HhvrfnException {
+        assert tasks != null && ui != null && storage != null
+            : "Parser.process(): collaborators must be non-null";
+
         if (input == null || input.trim().isEmpty()) {
             return; // ignore empty lines
         }

--- a/src/main/java/hhvrfn/Storage.java
+++ b/src/main/java/hhvrfn/Storage.java
@@ -85,14 +85,17 @@ public class Storage {
     // --- Format helpers: "T|1|desc", "D|0|desc|by", "E|0|desc|from-to"
 
     private String serialize(Task t) {
+        assert t != null : "Storage.serialize(): task must be non-null";
         String done = t.getStatusIcon().equals("X") ? "1" : "0";
         if (t instanceof Deadline) {
             Deadline d = (Deadline) t;
+            assert d.by != null : "Storage.serialize(): deadline 'by' is null";
             // persist ISO format: yyyy-MM-dd
             return "D | " + done + " | " + d.description + " | "
                     + d.by.format(DateTimeFormatter.ISO_LOCAL_DATE);
         } else if (t instanceof Event) {
             Event e = (Event) t;
+            assert e.from != null && e.to != null : "Storage.serialize(): event 'from/to' is null";
             return "E | " + done + " | " + e.description + " | " + e.from + " to " + e.to;
         } else { // Todo or legacy Task treated as TODO
             return "T | " + done + " | " + t.description;

--- a/src/main/java/hhvrfn/TaskList.java
+++ b/src/main/java/hhvrfn/TaskList.java
@@ -50,6 +50,8 @@ public class TaskList {
      * @return the task at the given index
      */
     public Task get(int indexZeroBased) {
+        assert indexZeroBased >= 0 && indexZeroBased < tasks.size()
+            : "TaskList.get(): index out of bounds after prior validation";
         return tasks.get(indexZeroBased);
     }
 
@@ -73,6 +75,7 @@ public class TaskList {
             return;
         }
         for (Task t : tasksToAdd) {
+            assert t != null : "TaskList.add(): null task element";
             tasks.add(t);
         }
     }
@@ -84,6 +87,8 @@ public class TaskList {
      * @return the removed task
      */
     public Task remove(int indexZeroBased) {
+        assert indexZeroBased >= 0 && indexZeroBased < tasks.size()
+            : "TaskList.remove(): index out of bounds after prior validation";
         return tasks.remove(indexZeroBased);
     }
 


### PR DESCRIPTION
Enable -ea for Gradle run. Add developer assertions in TaskList.add(varargs), Storage.parseLine, and Parser.process to document non-null and format assumptions. These do not replace user-facing validations.